### PR TITLE
[FIX] fixed when update user's tag, previous tag data remains -> Modi…

### DIFF
--- a/src/main/java/com/sullung2yo/seatcatcher/user/domain/User.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/user/domain/User.java
@@ -58,7 +58,7 @@ public class User extends BaseEntity {
     @Column
     private LocalDateTime lastLoginAt; // 마지막 로그인 시간
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", orphanRemoval = true, cascade = CascadeType.ALL)
     @Builder.Default
     private Set<UserTag> userTag = new HashSet<>(); // 사용자 태그 (M:N 관계 -> UserTag Entity 참조)
 

--- a/src/main/java/com/sullung2yo/seatcatcher/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/user/service/UserServiceImpl.java
@@ -86,7 +86,11 @@ public class UserServiceImpl implements UserService {
 
         // 태그 정보 업데이트
         List<UserTagType> tags = userInformationUpdateRequest.getTags();
-        user.getUserTag().clear(); // 기존 태그 관계 제거 -> 새로 생성
+
+        // 기존 태그 관계 제거 -> 새로 생성
+        userTagRepository.deleteAll(user.getUserTag());
+        user.getUserTag().clear();
+
         if (tags != null) {
             log.debug("사용자 태그 업데이트 개수: {}", tags.size());
             // 새 태그 관계 설정


### PR DESCRIPTION
…fied User Entitiy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 사용자 태그 정보가 업데이트될 때 이전 태그 정보가 데이터베이스에서 올바르게 삭제되도록 개선되었습니다.  
- **리팩터**
  - 사용자와 태그 간의 연관 관계 관리 방식이 개선되어 데이터 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->