### PR TITLE
hotfix(auth): fixed status code mismatch

### DIFF
--- a/src/main/java/com/sullung2yo/seatcatcher/common/exception/AuthException.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/common/exception/AuthException.java
@@ -1,0 +1,13 @@
+package com.sullung2yo.seatcatcher.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public AuthException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/sullung2yo/seatcatcher/common/exception/ErrorCode.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/common/exception/ErrorCode.java
@@ -27,7 +27,10 @@ public enum ErrorCode {
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "알람을 찾을 수 없습니다."),
     ALARM_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 이력에 접근할 수 없습니다."),
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    YIELD_ACCEPT_FAILED(HttpStatus.BAD_REQUEST, "양도 요청 수락에 실패했습니다.");
+    YIELD_ACCEPT_FAILED(HttpStatus.BAD_REQUEST, "양도 요청 수락에 실패했습니다."),
+    AUTH_INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 제공자입니다."),
+    AUTH_KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서버 오류"),
+    AUTH_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "인증 정보 파싱 오류");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/sullung2yo/seatcatcher/user/controller/AuthController.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/user/controller/AuthController.java
@@ -51,20 +51,16 @@ public class AuthController {
             }
     )
     public ResponseEntity<?> authenticateApple(@Valid @RequestBody AppleAuthRequest appleAuthRequest) {
-        try {
-            // RequestBody로 제대로 들어왔는지 검증
-            if (appleAuthRequest.getIdentityToken() == null || appleAuthRequest.getIdentityToken().isEmpty()) {
-                throw new IllegalArgumentException("Apple 인증 요청에 필요한 identityToken이 제공되지 않았습니다.");
-            }
-            log.debug("Authenticate with Apple: {}", appleAuthRequest);
-
-            // 인증 로직 수행 후 토큰 생성
-            List<String> tokens = authServiceImpl.authenticate(appleAuthRequest, Provider.APPLE);
-
-            return returnAfterTokenValidation(tokens);
-        } catch (Exception e) {
-            throw new RuntimeException("애플 인증 처리 중 오류가 발생했습니다: " + e.getMessage(), e);
+        // RequestBody로 제대로 들어왔는지 검증
+        if (appleAuthRequest.getIdentityToken() == null || appleAuthRequest.getIdentityToken().isEmpty()) {
+            throw new IllegalArgumentException("Apple 인증 요청에 필요한 identityToken이 제공되지 않았습니다.");
         }
+        log.debug("Authenticate with Apple: {}", appleAuthRequest);
+
+        // 인증 로직 수행 후 토큰 생성
+        List<String> tokens = authServiceImpl.authenticate(appleAuthRequest, Provider.APPLE);
+
+        return returnAfterTokenValidation(tokens);
     }
 
 

--- a/src/main/java/com/sullung2yo/seatcatcher/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/user/service/AuthServiceImpl.java
@@ -9,6 +9,10 @@ import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.jwt.SignedJWT;
+import com.sullung2yo.seatcatcher.common.exception.AuthException;
+import com.sullung2yo.seatcatcher.common.exception.ErrorCode;
+import com.sullung2yo.seatcatcher.common.exception.TagException;
+import com.sullung2yo.seatcatcher.common.exception.TokenException;
 import com.sullung2yo.seatcatcher.jwt.domain.TokenType;
 import com.sullung2yo.seatcatcher.jwt.provider.JwtTokenProviderImpl;
 import com.sullung2yo.seatcatcher.user.domain.Provider;
@@ -23,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
 import java.io.IOException;
 import java.net.URL;
@@ -57,13 +60,9 @@ public class AuthServiceImpl implements AuthService {
         this.nameGenerator = nameGenerator;
     }
 
-    public List<String> authenticate(Object request, Provider provider) throws Exception {
+    public List<String> authenticate(Object request, Provider provider) {
 
-        if (provider == Provider.LOCAL) {
-            // TODO: 로컬 인증 구현 필요 시 구현예정
-            throw new UnsupportedOperationException("로컬 인증 미구현");
-        }
-        else if (provider == Provider.KAKAO) {
+        if (provider == Provider.KAKAO) {
             // 카카오에 사용자 정보 요청
             KakaoAuthRequest kakaoAuthRequest = (KakaoAuthRequest) request;
             User user = kakaoAuthenticator(kakaoAuthRequest);
@@ -102,9 +101,8 @@ public class AuthServiceImpl implements AuthService {
             );
             log.info("JWT 토큰 생성 완료: accessToken={}, refreshToken={}", accessToken, refreshToken);
             return List.of(accessToken, refreshToken);
-        }
-        else {
-            throw new Exception("Invalid provider");
+        } else {
+            throw new AuthException("지원하지 않는 Provider 입니다.", ErrorCode.AUTH_INVALID_PROVIDER);
         }
     }
 
@@ -118,7 +116,7 @@ public class AuthServiceImpl implements AuthService {
         return jwtTokenProvider.validateToken(token, TokenType.ACCESS);
     }
 
-    private User kakaoAuthenticator(KakaoAuthRequest kakaoAuthRequest) throws Exception {
+    private User kakaoAuthenticator(KakaoAuthRequest kakaoAuthRequest) {
         String kakaoDataUrl = "https://kapi.kakao.com/v2/user/me";
 
         KakaoUserDataResponse response = webClient.get()
@@ -130,7 +128,7 @@ public class AuthServiceImpl implements AuthService {
                 .block();
 
         if (response == null) {
-            throw new Exception("카카오 서버에서 사용자 정보를 가져오는데 실패했습니다.");
+            throw new AuthException("카카오 서버에서 사용자 정보를 가져오는데 실패했습니다.", ErrorCode.AUTH_KAKAO_SERVER_ERROR);
         }
 
         // Check if the user is already registered
@@ -156,7 +154,7 @@ public class AuthServiceImpl implements AuthService {
         return user;
     }
 
-    private User appleAuthenticator(AppleAuthRequest appleAuthRequest) throws Exception {
+    private User appleAuthenticator(AppleAuthRequest appleAuthRequest) {
         log.debug("appleAuthenticator 메서드 호출됨");
 
         String providerId = validateAppleIdentityToken(appleAuthRequest.getIdentityToken());
@@ -181,7 +179,7 @@ public class AuthServiceImpl implements AuthService {
         return user;
     }
 
-    public String validateAppleIdentityToken(String identityToken) throws Exception {
+    public String validateAppleIdentityToken(String identityToken) {
         try {
             log.debug("validateAppleIdentityToken 메서드 호출됨 -> IdentityToken 검증 시작 : {}", identityToken);
 
@@ -197,19 +195,19 @@ public class AuthServiceImpl implements AuthService {
             // 1. exp 검증
             Date expirationTime = claimsSet.getExpirationTime();
             if (expirationTime == null || expirationTime.before(new Date())) {
-                throw new Exception("This identity token is expired");
+                throw new TokenException("This identity token is expired", ErrorCode.EXPIRED_TOKEN);
             }
             log.debug("성공적으로 exp 검증 완료");
 
             // 2. iss 검증
             if (!claimsSet.getIssuer().equals(issuer)) {
-                throw new Exception("This identity token is not issued by Apple");
+                throw new TokenException("This identity token is not issued by Apple", ErrorCode.INVALID_TOKEN);
             }
             log.debug("성공적으로 iss 검증 완료");
 
             // 3. aud 검증 ( Apple Developer 계정의 Client ID와 일치하는지 검증)
             if (!claimsSet.getAudience().contains(appleClientId)) {
-                throw new Exception("This identity token is not intended for this client");
+                throw new TokenException("This identity token is not intended for this client", ErrorCode.INVALID_TOKEN);
             }
             log.debug("성공적으로 aud 검증 완료");
 
@@ -231,19 +229,19 @@ public class AuthServiceImpl implements AuthService {
                         break;
                     } catch (Exception e) {
                         log.error("키 매칭 중 에러 발생: {}", e.getMessage());
-                        throw new Exception("키 매칭 중 에러 발생 : " + e.getMessage());
+                        throw new TokenException("키 매칭 중 에러 발생 : " + e.getMessage(), ErrorCode.INVALID_TOKEN);
                     }
                 }
             }
 
             if (publicKey == null) {
-                throw new Exception("identityToken에서 추출한 keyId와 애플에서 제공하는 Public KeyId가 일치하지 않습니다.");
+                throw new TokenException("identityToken에서 추출한 keyId와 애플에서 제공하는 Public KeyId가 일치하지 않습니다.", ErrorCode.INVALID_TOKEN);
             }
 
             RSASSAVerifier verifier = new RSASSAVerifier(publicKey.toRSAPublicKey());
             if (!signedJWT.verify(verifier)) {
                 log.error("identityToken의 signature 검증 실패");
-                throw new Exception("identityToken의 signature 검증 실패");
+                throw new TokenException("identityToken의 signature 검증 실패", ErrorCode.INVALID_TOKEN);
             }
 
             // 최종적으로 애플이 제공한 사용자 ID를 반환한다
@@ -252,22 +250,22 @@ public class AuthServiceImpl implements AuthService {
 
         } catch (ParseException e) {
             log.error("Parse error during token validation", e);
-            throw new Exception("애플 IdentityToken 검증 오류: " + e.getMessage());
+            throw new TokenException("애플 IdentityToken 검증 오류: " + e.getMessage(), ErrorCode.INVALID_TOKEN);
         } catch (JOSEException e) {
             log.error("JOSE error during token validation", e);
-            throw new Exception("애플 IdentityToken 검증 오류: " + e.getMessage());
-        } catch (Exception e) {
-            log.error("Unexpected error during token validation", e);
-            throw new Exception("애플 IdentityToken 검증 오류: " + e.getMessage());
+            throw new TokenException("애플 IdentityToken 검증 오류: " + e.getMessage(), ErrorCode.INVALID_TOKEN);
+        } catch (IllegalArgumentException e) {
+            log.error("IllegalArgumentException during token validation", e);
+            throw new TokenException("올바르지 않은 IdentityToken입니다: " + e.getMessage(), ErrorCode.INVALID_TOKEN);
         }
     }
 
-    private JWKSet loadApplePublicKeys() throws Exception {
+    private JWKSet loadApplePublicKeys() {
         try {
             String applePublicKeyUrl = "https://appleid.apple.com/auth/keys";
             return JWKSet.load(new URL(applePublicKeyUrl));
-        } catch (IOException e) {
-            throw new Exception("애플 PublicKey를 가져오는데 실패했습니다", e);
+        } catch (ParseException | IOException e) {
+            throw new AuthException("애플 PublicKey를 파싱하는데 실패했습니다", ErrorCode.AUTH_PARSE_ERROR);
         }
     }
 }

--- a/src/test/java/com/sullung2yo/seatcatcher/auth/AppleAuthTest.java
+++ b/src/test/java/com/sullung2yo/seatcatcher/auth/AppleAuthTest.java
@@ -1,5 +1,6 @@
 package com.sullung2yo.seatcatcher.auth;
 
+import com.sullung2yo.seatcatcher.common.exception.TokenException;
 import com.sullung2yo.seatcatcher.jwt.domain.TokenType;
 import com.sullung2yo.seatcatcher.jwt.provider.JwtTokenProviderImpl;
 import com.sullung2yo.seatcatcher.user.domain.Provider;
@@ -145,10 +146,11 @@ class AppleAuthTest {
         // Given
         AppleAuthRequest request = new AppleAuthRequest();
         request.setIdentityToken("invalid.token");
+        request.setFcmToken("fcmToken");
 
         // When/Then
-        Exception exception = assertThrows(Exception.class, () ->
+        Exception exception = assertThrows(TokenException.class, () ->
                 authService.authenticate(request, Provider.APPLE));
-        assertTrue(exception.getMessage().contains("애플 IdentityToken 검증 오류"));
+        assertTrue(exception.getMessage().contains("올바르지 않은 IdentityToken"));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 인증 과정에서 발생하는 오류에 대해 더 구체적인 예외 메시지와 오류 코드가 제공됩니다.
  - 애플 인증 토큰이 유효하지 않을 때 사용자에게 명확한 오류 메시지가 반환됩니다.

- **테스트**
  - 애플 인증 실패 시 예상되는 예외 및 메시지 검증 테스트가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->