### PR TITLE
[ADD] Credit endpoint added

### DIFF
--- a/src/main/java/com/sullung2yo/seatcatcher/subway_station/controller/PathHistoryController.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/subway_station/controller/PathHistoryController.java
@@ -10,6 +10,7 @@ import com.sullung2yo.seatcatcher.subway_station.dto.request.PathHistoryRequest;
 import com.sullung2yo.seatcatcher.subway_station.dto.request.StartJourneyRequest;
 import com.sullung2yo.seatcatcher.subway_station.dto.response.PathHistoryResponse;
 import com.sullung2yo.seatcatcher.subway_station.dto.response.StartJourneyResponse;
+import com.sullung2yo.seatcatcher.subway_station.dto.response.SubwayStationResponse;
 import com.sullung2yo.seatcatcher.subway_station.service.PathHistoryRealtimeUpdateService;
 import com.sullung2yo.seatcatcher.subway_station.service.PathHistoryService;
 import com.sullung2yo.seatcatcher.train.domain.TrainArrivalState;
@@ -125,7 +126,11 @@ public class PathHistoryController {
             summary = "도착까지 남은 시간 주기적 갱신 API",
             description = "해당 API 호출 시점부터 차량에 탑승한 것으로 판단, 도착까지 남은 시간을 주기적으로 계산하여 갱신합니다."
     )
-    @ApiResponse(responseCode = "201", description = "성공적으로 PathHistory 생성 & 스케줄링 완료.")
+    @ApiResponse(
+            responseCode = "201",
+            description = "성공적으로 PathHistory 생성 & 스케줄링 완료.",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = StartJourneyResponse.class))
+    )
     @ApiResponse(responseCode = "400", description = "잘못된 요청.")
     public ResponseEntity<StartJourneyResponse> startJourney(
             @RequestHeader("Authorization") String bearerToken,

--- a/src/main/java/com/sullung2yo/seatcatcher/user/controller/UserController.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.sullung2yo.seatcatcher.user.controller;
 
 import com.sullung2yo.seatcatcher.common.exception.ErrorCode;
 import com.sullung2yo.seatcatcher.common.exception.TokenException;
+import com.sullung2yo.seatcatcher.common.exception.UserException;
+import com.sullung2yo.seatcatcher.common.exception.dto.ErrorResponse;
 import com.sullung2yo.seatcatcher.user.domain.User;
 import com.sullung2yo.seatcatcher.user.domain.UserTagType;
 import com.sullung2yo.seatcatcher.user.dto.request.UserInformationUpdateRequest;
@@ -128,5 +130,67 @@ public class UserController {
                         .hasOnBoarded(user.getHasOnBoarded())
                         .build()
         );
+    }
+
+    @PatchMapping("/credit/increase")
+    @Operation(
+            summary = "사용자 크레딧 증가 API",
+            description = "사용자의 크레딧을 직접 증가시키는 Endpoint입니다. 내부적으로 PATCH :: /user/me 와 동일한 동작을 수행합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "유저의 총 크레딧 업데이트 완료"
+                    )
+            }
+    )
+    public ResponseEntity<UserInformationResponse> increaseCredit(
+            @RequestHeader("Authorization") String bearerToken,
+            @RequestParam(required = true) long amount
+    )
+    {
+        // Bearer 토큰 검증
+        if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
+            log.error("올바른 JWT 형식이 아닙니다.");
+            throw new TokenException("올바른 JWT 형식이 아닙니다.", ErrorCode.INVALID_TOKEN);
+        }
+        String token = bearerToken.replace("Bearer ", "");
+        log.debug("JWT 파싱 성공");
+
+        User user = userService.increaseCredit(token, amount);
+
+        return getUserInformationResponseResponseEntity(user);
+    }
+
+    @PatchMapping("/credit/decrease")
+    @Operation(
+            summary = "사용자 크레딧 감소 API",
+            description = "사용자의 크레딧을 직접 감소시키는 Endpoint입니다. 내부적으로 PATCH :: /user/me 와 동일한 동작을 수행합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "유저의 총 크레딧 업데이트 완료"
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Bad Request - 잔액이 부족하여 실패했음."
+                    )
+            }
+    )
+    public ResponseEntity<UserInformationResponse> decreaseCredit(
+            @RequestHeader("Authorization") String bearerToken,
+            @RequestParam(required = true) long amount
+    )
+    {
+        // Bearer 토큰 검증
+        if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
+            log.error("올바른 JWT 형식이 아닙니다.");
+            throw new TokenException("올바른 JWT 형식이 아닙니다.", ErrorCode.INVALID_TOKEN);
+        }
+        String token = bearerToken.replace("Bearer ", "");
+        log.debug("JWT 파싱 성공");
+
+        User user = userService.decreaseCredit(token, amount);
+
+        return getUserInformationResponseResponseEntity(user);
     }
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/user/domain/CreditPolicy.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/user/domain/CreditPolicy.java
@@ -1,0 +1,14 @@
+package com.sullung2yo.seatcatcher.user.domain;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CreditPolicy {
+
+    CREDIT_FOR_SIT_INFO_PROVIDE(300);
+
+    private final int credit;
+}

--- a/src/main/java/com/sullung2yo/seatcatcher/user/service/UserService.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/user/service/UserService.java
@@ -10,4 +10,11 @@ public interface UserService {
     User getUserWithToken(String token) throws RuntimeException;
     User updateUser(String token, UserInformationUpdateRequest userInformationUpdateRequest) throws RuntimeException;
     void deleteUser(String token) throws RuntimeException;
+
+    // Endpoint용 Service.
+    User increaseCredit(String token, long amount) throws RuntimeException;
+    User decreaseCredit(String token, long amount) throws RuntimeException;
+    // 내부 로직용 Service. 로직 중간에 크레딧 변경이 일어나야 할 경우 해당 서비스 이용하면 됨.
+    User increaseCredit(User user, long amount) throws RuntimeException;
+    User decreaseCredit(User user, long amount) throws RuntimeException;
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/user/service/UserServiceImpl.java
@@ -147,4 +147,45 @@ public class UserServiceImpl implements UserService {
         userRepository.delete(user);
         log.debug("사용자 정보 삭제");
     }
+
+    @Override
+    public User increaseCredit(String token, long amount) throws RuntimeException {
+        // 사용자 정보 가져오기
+        User user = this.getUserWithToken(token);
+        // 서비스 호출
+        return this.increaseCredit(user, amount);
+    }
+
+    @Override
+    public User decreaseCredit(String token, long amount) throws RuntimeException {
+        // 사용자 정보 가져오기
+        User user = this.getUserWithToken(token);
+        // 서비스 호출
+        return this.decreaseCredit(user, amount);
+    }
+
+    @Override
+    public User increaseCredit(User user, long amount) throws RuntimeException {
+        long creditToUpdate = user.getCredit() + amount;
+        return updateCredit(user, creditToUpdate);
+    }
+
+    @Override
+    public User decreaseCredit(User user, long amount) throws RuntimeException {
+        long creditToUpdate = user.getCredit() - amount;
+        return updateCredit(user, creditToUpdate);
+    }
+
+    private User updateCredit(User user, long creditToUpdate) throws RuntimeException {
+
+        if (creditToUpdate < 0) {
+            throw new UserException("크레딧은 0보다 작을 수 없습니다.", ErrorCode.INVALID_PROFILE_IMAGE_NUM);
+        }
+
+        log.debug("사용자 크레딧 업데이트: {}", creditToUpdate);
+        user.setCredit(creditToUpdate);
+        userRepository.save(user);
+
+        return user;
+    }
 }

--- a/src/test/java/com/sullung2yo/seatcatcher/user/controller/UserControllerTest.java
+++ b/src/test/java/com/sullung2yo/seatcatcher/user/controller/UserControllerTest.java
@@ -8,6 +8,7 @@ import com.sullung2yo.seatcatcher.user.dto.request.UserInformationUpdateRequest;
 import com.sullung2yo.seatcatcher.user.repository.TagRepository;
 import com.sullung2yo.seatcatcher.user.repository.UserRepository;
 import com.sullung2yo.seatcatcher.user.repository.UserTagRepository;
+import com.sullung2yo.seatcatcher.user.service.UserService;
 import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
@@ -147,6 +148,41 @@ class UserControllerTest {
         Optional<User> foundUser = userRepository.findByProviderId("testProviderId");
         assertThat(foundUser).isEmpty();
         assertThat(userTags).isEmpty();
+    }
+
+    @Test
+    void increaseTokenTest() throws Exception {
+        // When
+        mockMvc.perform(patch("/user/credit/increase")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("amount", String.valueOf(100L)))
+
+                // Then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.credit").value(223L));
+    }
+
+    @Test
+    void decreaseTokenTest() throws Exception {
+        // When
+        mockMvc.perform(patch("/user/credit/decrease")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("amount", String.valueOf(100L)))
+
+                // Then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.credit").value(23L));
+
+        // When
+        mockMvc.perform(patch("/user/credit/decrease")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("amount", String.valueOf(10000L))) // 잔액보다 터무니없이 많은 값이 감소될 경우
+
+                // Then
+                .andExpect(status().isBadRequest());
     }
 
     @AfterEach

--- a/src/test/java/com/sullung2yo/seatcatcher/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/sullung2yo/seatcatcher/user/service/UserServiceImplTest.java
@@ -1,0 +1,86 @@
+package com.sullung2yo.seatcatcher.user.service;
+
+import com.sullung2yo.seatcatcher.jwt.domain.TokenType;
+import com.sullung2yo.seatcatcher.jwt.provider.JwtTokenProviderImpl;
+import com.sullung2yo.seatcatcher.user.domain.*;
+import com.sullung2yo.seatcatcher.user.repository.TagRepository;
+import com.sullung2yo.seatcatcher.user.repository.UserRepository;
+import com.sullung2yo.seatcatcher.user.repository.UserTagRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+public class UserServiceImplTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private UserTagRepository userTagRepository;
+
+    @Autowired
+    private JwtTokenProviderImpl jwtTokenProvider;
+
+    private String accessToken;
+
+    private User user;
+    @Autowired
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트할 사용자 생성
+        user = User.builder()
+                .provider(Provider.APPLE)
+                .providerId("testProviderId")
+                .name("testUser")
+                .credit(123L)
+                .profileImageNum(ProfileImageNum.IMAGE_1)
+                .build();
+        userRepository.save(user);
+
+        Tag tag = tagRepository.findByTagName(UserTagType.USERTAG_CARRIER).get();
+
+        UserTag userTag = UserTag.builder()
+                .user(user)
+                .tag(tag)
+                .build();
+        userTag.setRelationships(user, tag);
+        userTagRepository.save(userTag);
+
+        // Access 토큰 생성
+        accessToken = jwtTokenProvider.createToken(user.getProviderId(), null, TokenType.ACCESS);
+    }
+
+    @Test
+    void increaseCreditForInternalImplementTest()
+    {
+        // When
+        User updatedUser = userService.increaseCredit(user, 100L);
+
+        // then
+        assertThat(updatedUser.getCredit()).isEqualTo(223L);
+    }
+
+    @Test
+    void decreaseCreditForInternalImplementTest()
+    {
+        // When
+        User updatedUser = userService.decreaseCredit(user, 100L);
+
+        // then
+        assertThat(updatedUser.getCredit()).isEqualTo(23L);
+    }
+}


### PR DESCRIPTION
프론트측에서 편하게 Credit 증감 작업을 할 수 있도록 전용 엔드포인트를 개설했습니다. ( /user/credit/increase 등 )

내부 로직에 쓰일 개발용 서비스도 UserService 에 만들어 놓았으니 많은 이용 부탁드립니다.

테스트 코드도 모두 작성되었고 잔액이 부족한 상황 등에 대한 예외처리도 구현 완료 / 테스트 완료 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 사용자의 크레딧을 직접 증가/감소할 수 있는 PATCH API 엔드포인트가 추가되었습니다.
    - 사용자 크레딧 정책을 관리하는 새로운 정책(enum)이 도입되었습니다.

- **문서화**
    - 일부 엔드포인트의 응답 구조가 Swagger/OpenAPI 문서에 명확히 반영되었습니다.

- **테스트**
    - 크레딧 증감 기능에 대한 컨트롤러 및 서비스 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->