### PR TITLE
[FIX] add example on StartJourneyResponse

### DIFF
--- a/src/main/java/com/sullung2yo/seatcatcher/subway_station/dto/response/StartJourneyResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/subway_station/dto/response/StartJourneyResponse.java
@@ -17,7 +17,7 @@ public class StartJourneyResponse {
     @Schema(description = "앞으로 추적해야 하는, 생성된 PathHistory 의 id")
     private Long pathHistoryId;
 
-    @Schema(description = "생성한 PathHistory 의 Expected Arrival Time")
+    @Schema(description = "생성한 PathHistory 의 Expected Arrival Time", example = "2025-06-01 14:30")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime expectedArrivalTime;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Swagger/OpenAPI 문서에서 `expectedArrivalTime` 필드에 예시 값("2025-06-01 14:30")이 추가되어, 날짜 및 시간 형식이 명확하게 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->