### PR TITLE
[FIX] Fix StartJourney API

### DIFF
--- a/src/main/java/com/sullung2yo/seatcatcher/subway_station/controller/PathHistoryController.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/subway_station/controller/PathHistoryController.java
@@ -166,9 +166,11 @@ public class PathHistoryController {
 
         if(nextScheduleTime < 360)
         {
-            nextScheduleDateTime = LocalDateTime.now().plusSeconds(nextScheduleTime);
             // 이 정도면 곧바로 실시간으로 업데이트가 가능함. 스케줄링 맡기지 말고 즉시 한 번 업데이트하자!
-            pathHistoryRealtimeUpdateService.updateArrivalTimeAndSchedule(latestPathHistory, request.getTrainCode(), TrainArrivalState.STATE_NOT_FOUND);
+            nextScheduleDateTime = scheduleService.runThisAfterSeconds(10, ()->
+            {
+                pathHistoryRealtimeUpdateService.updateArrivalTimeAndSchedule(latestPathHistory, request.getTrainCode(), TrainArrivalState.STATE_NOT_FOUND);
+            });
         }
         else
         {


### PR DESCRIPTION
생각해보니까 이렇게 하면 프론트측에서 메시지를 못 받아서 바로 탐지 가능한 거리에 있는 경우 10초 뒤에 바로 갱신 이벤트가 발생하도록 해놨습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 다음 스케줄 시간이 360초 미만일 때 도착 시간 업데이트가 즉시 실행되지 않고, 10초 후에 예약 실행되도록 동작이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->