### PR TITLE
[FIX] Add publish logic on startJourney API

### DIFF
--- a/src/main/java/com/sullung2yo/seatcatcher/subway_station/service/PathHistoryRealtimeUpdateServiceImpl.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/subway_station/service/PathHistoryRealtimeUpdateServiceImpl.java
@@ -305,11 +305,14 @@ public class PathHistoryRealtimeUpdateServiceImpl implements PathHistoryRealtime
         long userId = pathHistory.getUser().getId();
 
         if(userTrainSeatService.isUserSitting(userId)) {
+            TrainCarDTO dto = trainSeatGroupService.getSittingTrainCarInfo(pathHistory.getUser());
+
             userTrainSeatService.releaseSeat(userId);
             userAlarmService.sendArrivalHandledAlarm(pathHistory.getUser().getFcmToken()); // 이야 만들어놓으셨네요?? 좋습니다!
+
+            //Seat Event Publish 가 일어나야 함.
+            if(dto != null) seatEventService.publishSeatEvent(dto.getTrainCode(), dto.getCarCode());
         }
-
-
     }
 
     private void onShouldRefreshPathHistory(PathHistory pathHistory, LocalDateTime value)


### PR DESCRIPTION
사용자가 자동하차 처리가 될 경우 releaseSeat 만 하게 되어 있었는데, 해당 코드에 있던 publishSeatEvent 로직이 지금 확인해보니 없어져서 따로 추가했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 사용자의 좌석 해제 및 도착 알림 처리 후, 좌석 이벤트가 올바르게 조건부로 발행되도록 동작이 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->