### PR TITLE
fix: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,5 @@ src/main/.DS_Store
 
 ### Spring Boot ###
 src/main/resources/*.properties
-
+src/main/resources/*.p8
 /src/main/resources/seat-catcher-firebase-adminsdk-fbsvc-5d0ae449ec.json


### PR DESCRIPTION
Update gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Spring Boot 섹션에 `src/main/resources/*.p8` 파일이 Git 추적 대상에서 제외되도록 `.gitignore`가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->