### PR TITLE
feat: FcmControllerTest 구현 & fix: FcmRequest, saveToken 수정

### DIFF
--- a/src/main/java/com/sullung2yo/seatcatcher/domain/alarm/dto/request/FcmRequest.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/alarm/dto/request/FcmRequest.java
@@ -20,7 +20,7 @@ public class FcmRequest {
     @Setter
     @AllArgsConstructor
     @NoArgsConstructor
-    public class Token{
+    public static class Token{
         private String token;
 
     }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/alarm/service/FcmServiceImpl.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/alarm/service/FcmServiceImpl.java
@@ -13,6 +13,7 @@ import com.sullung2yo.seatcatcher.domain.alarm.dto.request.FcmMessageWithData;
 import com.sullung2yo.seatcatcher.domain.alarm.dto.request.FcmRequest;
 import com.sullung2yo.seatcatcher.domain.user.repository.UserRepository;
 import com.sullung2yo.seatcatcher.domain.user.service.UserService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -100,6 +101,7 @@ public class FcmServiceImpl implements FcmService {
     }
 
     @Override
+    @Transactional
     public void saveToken(FcmRequest.Token request) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String providerId = authentication.getName();

--- a/src/test/java/com/sullung2yo/seatcatcher/domain/alarm/controller/FcmControllerTest.java
+++ b/src/test/java/com/sullung2yo/seatcatcher/domain/alarm/controller/FcmControllerTest.java
@@ -17,11 +17,11 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -47,47 +47,52 @@ class FcmControllerTest {
     }
 
     @Test
+    @WithMockUser(username = "test_provider")
     @DisplayName("FCM 토큰 저장 성공 - 유효한 사용자일 경우")
     void saveFcmToken_success() throws Exception {
-        // given
+        // given: 유저 생성 및 저장
         User user = new User();
         user.setProviderId("test_provider");
         user.setFcmToken(null);
-        user.setName("Test User"); // 필수
-        user.setPassword("test1234"); // 만약 null 불가면
-        user.setEmail("test@example.com"); // 마찬가지
-        user.setRole(UserRole.ROLE_USER); // enum 값 채워야 함
-        user.setProvider(Provider.KAKAO); // Enum 값도 정확히 존재하는 값으로
+        user.setName("Test User");
+        user.setPassword("test1234");
+        user.setEmail("test@example.com");
+        user.setRole(UserRole.ROLE_USER);
+        user.setProvider(Provider.KAKAO);
         userRepository.save(user);
 
+        // 인증 정보 설정
         setAuthentication("test_provider");
 
-        FcmRequest.Token request = new FcmRequest().new Token("test_token");
+        // 요청 객체 생성
+        FcmRequest.Token request = new FcmRequest.Token("test_token");
 
-        // when + then
+        // when + then: 요청 수행 및 검증
         mockMvc.perform(post("/fcm/token")
                         .with(authentication(new UsernamePasswordAuthenticationToken("test_provider", null, List.of())))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
 
+        // DB에서 유저를 다시 불러와 토큰이 저장됐는지 확인
         User updatedUser = userRepository.findByProviderId("test_provider").orElseThrow();
         assertEquals("test_token", updatedUser.getFcmToken());
     }
 
     @Test
+    @WithMockUser(username = "test_provider")
     @DisplayName("FCM 토큰 저장 실패 - 사용자 없음")
     void saveFcmToken_userNotFound() throws Exception {
-        // given
-        setAuthentication("missing_provider");
+        // 인증 정보 설정 (없는 사용자 ID)
+        setAuthentication("not_exist_user");
 
-        FcmRequest.Token request = new FcmRequest().new Token("test_token");
+        FcmRequest.Token request = new FcmRequest.Token("test_token");
 
-        // when + then
         mockMvc.perform(post("/fcm/token")
+                        .with(authentication(new UsernamePasswordAuthenticationToken("test_provider", null, List.of())))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isNotFound()); // 여기 고침
     }
 
     private void setAuthentication(String providerId) {

--- a/src/test/java/com/sullung2yo/seatcatcher/domain/alarm/controller/FcmControllerTest.java
+++ b/src/test/java/com/sullung2yo/seatcatcher/domain/alarm/controller/FcmControllerTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -65,10 +66,10 @@ class FcmControllerTest {
 
         // when + then
         mockMvc.perform(post("/fcm/token")
+                        .with(authentication(new UsernamePasswordAuthenticationToken("test_provider", null, List.of())))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("token을 저장하였습니다.")));
+                .andExpect(status().isOk());
 
         User updatedUser = userRepository.findByProviderId("test_provider").orElseThrow();
         assertEquals("test_token", updatedUser.getFcmToken());

--- a/src/test/java/com/sullung2yo/seatcatcher/domain/alarm/controller/FcmControllerTest.java
+++ b/src/test/java/com/sullung2yo/seatcatcher/domain/alarm/controller/FcmControllerTest.java
@@ -1,0 +1,98 @@
+package com.sullung2yo.seatcatcher.domain.alarm.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sullung2yo.seatcatcher.domain.alarm.dto.request.FcmRequest;
+import com.sullung2yo.seatcatcher.domain.auth.enums.Provider;
+import com.sullung2yo.seatcatcher.domain.user.entity.User;
+import com.sullung2yo.seatcatcher.domain.user.enums.UserRole;
+import com.sullung2yo.seatcatcher.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FcmControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("FCM 토큰 저장 성공 - 유효한 사용자일 경우")
+    void saveFcmToken_success() throws Exception {
+        // given
+        User user = new User();
+        user.setProviderId("test_provider");
+        user.setFcmToken(null);
+        user.setName("Test User"); // 필수
+        user.setPassword("test1234"); // 만약 null 불가면
+        user.setEmail("test@example.com"); // 마찬가지
+        user.setRole(UserRole.ROLE_USER); // enum 값 채워야 함
+        user.setProvider(Provider.KAKAO); // Enum 값도 정확히 존재하는 값으로
+        userRepository.save(user);
+
+        setAuthentication("test_provider");
+
+        FcmRequest.Token request = new FcmRequest().new Token("test_token");
+
+        // when + then
+        mockMvc.perform(post("/fcm/token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("token을 저장하였습니다.")));
+
+        User updatedUser = userRepository.findByProviderId("test_provider").orElseThrow();
+        assertEquals("test_token", updatedUser.getFcmToken());
+    }
+
+    @Test
+    @DisplayName("FCM 토큰 저장 실패 - 사용자 없음")
+    void saveFcmToken_userNotFound() throws Exception {
+        // given
+        setAuthentication("missing_provider");
+
+        FcmRequest.Token request = new FcmRequest().new Token("test_token");
+
+        // when + then
+        mockMvc.perform(post("/fcm/token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+    }
+
+    private void setAuthentication(String providerId) {
+        Authentication authentication = new UsernamePasswordAuthenticationToken(providerId, null, List.of());
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+    }
+}

--- a/src/test/java/com/sullung2yo/seatcatcher/domain/alarm/service/FcmServiceImplTest.java
+++ b/src/test/java/com/sullung2yo/seatcatcher/domain/alarm/service/FcmServiceImplTest.java
@@ -53,8 +53,7 @@ public class FcmServiceImplTest {
 
         setAuthentication("test_provider");
 
-        FcmRequest fcmRequest = new FcmRequest();
-        FcmRequest.Token tokenRequest = fcmRequest.new Token("test_token");
+        FcmRequest.Token tokenRequest = new FcmRequest.Token("test_token");
 
         // when
         fcmService.saveToken(tokenRequest);
@@ -70,8 +69,7 @@ public class FcmServiceImplTest {
         // given
         setAuthentication("missing_provider");
 
-        FcmRequest fcmRequest = new FcmRequest();
-        FcmRequest.Token tokenRequest = fcmRequest.new Token("test_token");
+        FcmRequest.Token tokenRequest = new FcmRequest.Token("test_token");
 
         // when + then
         UserException ex = assertThrows(UserException.class, () -> {


### PR DESCRIPTION
- [x] FcmReqeust의 Token에 static 추가
- 불필요한 인스턴스 의존을 제거 + 논리적 독립성 부여
- [x] FcmServiceImpl saveToken에 @Transactional 어노테이션 추가
- DB 변경이 있는 메서드인데 트랜잭션이 없으면 변경 감지가 되지 않음. 실제 DB에 변경하기 위해 변경
- [x] FcmServiceImplTest 수정
- [x] FcmControllerTest 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * FCM 토큰 저장 로직이 트랜잭션으로 처리되어 안정성이 향상되었습니다.

* **테스트**
  * FCM 토큰 저장 API에 대한 통합 테스트가 추가되어 정상 동작 및 사용자 미존재 시의 예외 상황을 검증합니다.
  * 테스트 코드가 최신 구조에 맞게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->