### PR TITLE
fix: DTO 전면 불변화(Immutable) 및 공통 포맷 정리

### DIFF
--- a/src/main/java/com/sullung2yo/seatcatcher/domain/alarm/dto/request/FcmRequest.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/alarm/dto/request/FcmRequest.java
@@ -6,37 +6,32 @@ import lombok.*;
 public class FcmRequest {
 
     @Getter
-    @Setter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class Notification{
+    public static class Notification {
         private String targetToken;
         private String title;
         private String body;
     }
 
     @Getter
-    @Setter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class Token{
+    public static class Token {
         private String token;
-
     }
 
     @Getter
-    @Setter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class NotificationAndData{
+    public static class NotificationAndData {
         private String targetToken;
         private String title;
         private String body;
-
         private PushNotificationType type;
 
-        Object data;
+        private Object data;
     }
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/auth/dto/request/AppleAuthRequest.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/auth/dto/request/AppleAuthRequest.java
@@ -2,11 +2,12 @@ package com.sullung2yo.seatcatcher.domain.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "애플 인증 요청 DTO")
 public class AppleAuthRequest {
 

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/auth/dto/request/KakaoAuthRequest.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/auth/dto/request/KakaoAuthRequest.java
@@ -2,13 +2,14 @@ package com.sullung2yo.seatcatcher.domain.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "카카오 인증 요청 DTO")
-public class KakaoAuthRequest{
+public class KakaoAuthRequest {
 
     @NotNull
     @Schema(description = "카카오 Auth server에서 제공받은 accessToken", example = "qwer.asdf.zxcv")

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/auth/dto/request/TokenRefreshRequest.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/auth/dto/request/TokenRefreshRequest.java
@@ -1,14 +1,16 @@
 package com.sullung2yo.seatcatcher.domain.auth.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.Setter;
-
+import lombok.*;
 
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "토큰 갱신 요청 DTO")
 public class TokenRefreshRequest {
-    @Schema(description = "Refresh token", example="qwer.asdf.zxcv")
+
+    @Schema(description = "Refresh token", example = "qwer.asdf.zxcv")
     private String refreshToken;
 }
+

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/auth/dto/response/KakaoUserDataResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/auth/dto/response/KakaoUserDataResponse.java
@@ -1,10 +1,13 @@
 package com.sullung2yo.seatcatcher.domain.auth.dto.response;
 
-import lombok.Getter;
-import lombok.Setter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
 
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class KakaoUserDataResponse {
-    private String id; // Kakao user id
+    @Schema(description = "Kakao user id", example = "1234567890")
+    private String id;
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/auth/dto/response/TokenResponse.java
@@ -4,11 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
-@Setter
-@NoArgsConstructor
+@Builder
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "Access token 및 Refresh token 응답 DTO")
 public class TokenResponse {
+
     @Schema(description = "Access token", example = "qwer.asdf.zxcv")
     private String accessToken;
 

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/credit/dto/request/CreditModificationRequest.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/credit/dto/request/CreditModificationRequest.java
@@ -6,7 +6,9 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "크레딧 증감 요청 DTO")
 public class CreditModificationRequest {
 

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/path_history/dto/request/PathHistoryRequest.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/path_history/dto/request/PathHistoryRequest.java
@@ -1,20 +1,18 @@
 package com.sullung2yo.seatcatcher.domain.path_history.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
-@Setter
+@Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "경로 기록 요청 DTO")
 public class PathHistoryRequest {
 
     @Schema(description = "시작역 id")
-    Long startStationId;
+    private Long startStationId;
 
     @Schema(description = "도착역 id")
-    Long endStationId;
+    private Long endStationId;
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/path_history/dto/request/StartJourneyRequest.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/path_history/dto/request/StartJourneyRequest.java
@@ -3,15 +3,13 @@ package com.sullung2yo.seatcatcher.domain.path_history.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
-@Setter
+@Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "여정 시작 요청 DTO")
 public class StartJourneyRequest {
 
     @Schema(description = "출발역의 id", example = "212")
@@ -25,5 +23,4 @@ public class StartJourneyRequest {
     @Schema(description = "유저가 현재 탑승한 열차의 Code", example = "7102")
     @NotBlank(message = "열차 코드는 필수로 입력해야 합니다!")
     private String trainCode;
-
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/path_history/dto/response/PathHistoryResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/path_history/dto/response/PathHistoryResponse.java
@@ -11,52 +11,50 @@ import java.util.List;
 public class PathHistoryResponse {
 
     @Getter
-    @Setter
     @Builder
     @AllArgsConstructor
-    @NoArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @ToString
     public static class PathHistoryList {
         private List<PathHistoryInfoResponse> pathHistoryInfoList;
         private Long nextCursor; // 다음 커서 값
-        boolean isLast;
+        private boolean isLast;
     }
+
     @Getter
-    @Setter
     @Builder
     @AllArgsConstructor
-    @NoArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @ToString
-    public static class PathHistoryInfoResponse{
+    public static class PathHistoryInfoResponse {
 
         @Schema(description = "PathHistoryId 입니다.")
-        Long id;
+        private Long id;
 
         @Schema(description = "시작역 id 입니다.")
-        Long startStationId;
+        private Long startStationId;
 
         @Schema(description = "시작역 명 입니다.")
-        String startStationName;
+        private String startStationName;
 
         @Schema(description = "시작역 호선 정보입니다.")
-        Line startline;
+        private Line startline;
 
         @Schema(description = "도착역 id 입니다.")
-        Long endStationId;
+        private Long endStationId;
 
         @Schema(description = "도착역 명 입니다.")
-        String endStationName;
+        private String endStationName;
 
         @Schema(description = "도착역 호선 정보입니다.")
-        Line endline;
+        private Line endline;
 
-        //초 제외
+        // 초 제외
         @Schema(description = "예상 도착 시간을 나타냅니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
-        LocalDateTime expectedArrivalTime;
+        private LocalDateTime expectedArrivalTime;
 
         @Schema(description = "경로 생성일을 나타냅니다.")
-        String createdDate;
+        private String createdDate;
     }
-
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/path_history/dto/response/StartJourneyResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/path_history/dto/response/StartJourneyResponse.java
@@ -7,10 +7,10 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "여정 시작 응답 DTO")
 public class StartJourneyResponse {
 
     @Schema(description = "생성/추적중인 PathHistory 의 id")

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/report/dto/request/ReportRequest.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/report/dto/request/ReportRequest.java
@@ -1,13 +1,23 @@
 package com.sullung2yo.seatcatcher.domain.report.dto.request;
 
+import com.google.firebase.database.annotations.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @Getter
-@Setter
+@Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "신고 요청 DTO")
 public class ReportRequest {
+
+    @Schema(description = "신고자 ID")
     private Long reportUserId;
+
+    @Schema(description = "피신고자 ID")
     private Long reportedUserId;
+
+    @Schema(description = "신고 사유")
     private String reason;
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/report/dto/response/ReportResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/report/dto/response/ReportResponse.java
@@ -1,16 +1,27 @@
 package com.sullung2yo.seatcatcher.domain.report.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
-@Setter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "신고 응답 DTO")
 public class ReportResponse {
+
+    @Schema(description = "신고자 ID")
     private Long reportUserId;
+
+    @Schema(description = "신고자 이름")
     private String reportUserName;
+
+    @Schema(description = "피신고자 ID")
     private Long reportedUserId;
+
+    @Schema(description = "피신고자 이름")
     private String reportedUserName;
+
+    @Schema(description = "신고 사유")
     private String reason;
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/subway_station/controller/SubwayStationController.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/subway_station/controller/SubwayStationController.java
@@ -1,8 +1,8 @@
 package com.sullung2yo.seatcatcher.domain.subway_station.controller;
 
+import com.sullung2yo.seatcatcher.domain.subway_station.dto.response.SubwayStationResponse;
 import com.sullung2yo.seatcatcher.domain.subway_station.enums.Line;
 import com.sullung2yo.seatcatcher.domain.subway_station.entity.SubwayStation;
-import com.sullung2yo.seatcatcher.domain.subway_station.dto.response.SubwayStationResponse;
 import com.sullung2yo.seatcatcher.domain.subway_station.service.SubwayStationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/subway_station/dto/SubwayDataRoot.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/subway_station/dto/SubwayDataRoot.java
@@ -7,9 +7,17 @@ import lombok.Setter;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import java.util.List;
+import java.util.Map;
+
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SubwayDataRoot {
+
     // Description - json 파일 참고
     @JsonProperty("DESCRIPTION")
     private Map<String, String> description;

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/subway_station/dto/SubwayDataRoot.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/subway_station/dto/SubwayDataRoot.java
@@ -1,14 +1,8 @@
 package com.sullung2yo.seatcatcher.domain.subway_station.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
-
-import java.util.List;
-import java.util.Map;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
+
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/subway_station/dto/SubwayStationData.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/subway_station/dto/SubwayStationData.java
@@ -1,38 +1,50 @@
 package com.sullung2yo.seatcatcher.domain.subway_station.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SubwayStationData {
     /**
      * 서울 공공데이터에서 JSON 파일을 내려받아서 파싱
-     * 굳이 외부 API 호출하는것보다는 파일 있는거 쓰는게 좋을 듯 해서...
+     * 외부 API 호출 대신 파일 파싱 용도로 사용
      */
 
     @JsonProperty("acml_dist")
-    private float accumulatedDistance = 0.0f; // 기준역부터 축적거리 (km)
+    private float accumulatedDistance; // 기준역부터 축적거리 (km)
 
     @JsonProperty("sbwy_rout_ln")
-    private String subwayLine = ""; // 지하철 노선 번호 (1, 2, ...)
+    private String subwayLine; // 지하철 노선 번호 (1, 2, ...)
 
     @JsonProperty("dist_km")
-    private float distanceKm = 0.0f; // 현재 위치에서 다음 역까지 거리 (km)
+    private float distanceKm; // 현재 위치에서 다음 역까지 거리 (km)
 
     @JsonProperty("hm")
-    private String hourMinutes = "0:00"; // 현재 위치에서 다음 역까지 소요 시간 (H:MM)
+    private String hourMinutes; // 현재 위치에서 다음 역까지 소요 시간 (H:MM)
 
     @JsonProperty("sbwy_stns_nm")
-    private String subwayStationName = ""; // 지하철 역 이름 (서울시청, 강남역, ...)
+    private String subwayStationName; // 지하철 역 이름 (서울시청, 강남역, ...)
 
     @Override
     public String toString() {
-        return "노선번호 : " + (subwayLine.isEmpty() ? subwayLine : "") +
-                ", 역명 : " + (subwayStationName.isEmpty() ? subwayStationName : "") +
-                ", 축적거리 : " + (accumulatedDistance != 0.0f ? accumulatedDistance : "") +
-                ", 거리 : " + (distanceKm != 0.0f ? distanceKm : "") +
-                ", 소요시간 : " + (hourMinutes.equals("0:00") ? hourMinutes : "");
+        return String.format(
+                "노선번호: %s, 역명: %s, 축적거리(km): %s, 거리(km): %s, 소요시간: %s",
+                nullSafe(subwayLine),
+                nullSafe(subwayStationName),
+                floatSafe(accumulatedDistance),
+                floatSafe(distanceKm),
+                nullSafe(hourMinutes)
+        );
+    }
+
+    private String nullSafe(String s) {
+        return (s == null || s.isEmpty()) ? "-" : s;
+    }
+
+    private String floatSafe(float f) {
+        return f == 0.0f ? "-" : Float.toString(f);
     }
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/subway_station/dto/SubwayStationData.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/subway_station/dto/SubwayStationData.java
@@ -14,19 +14,24 @@ public class SubwayStationData {
      */
 
     @JsonProperty("acml_dist")
-    private float accumulatedDistance; // 기준역부터 축적거리 (km)
+    @Builder.Default
+    private float accumulatedDistance = 0.0f;
 
     @JsonProperty("sbwy_rout_ln")
-    private String subwayLine; // 지하철 노선 번호 (1, 2, ...)
+    @Builder.Default
+    private String subwayLine = "";
 
     @JsonProperty("dist_km")
-    private float distanceKm; // 현재 위치에서 다음 역까지 거리 (km)
+    @Builder.Default
+    private float distanceKm = 0.0f;
 
     @JsonProperty("hm")
-    private String hourMinutes; // 현재 위치에서 다음 역까지 소요 시간 (H:MM)
+    @Builder.Default
+    private String hourMinutes = "0:00";
 
     @JsonProperty("sbwy_stns_nm")
-    private String subwayStationName; // 지하철 역 이름 (서울시청, 강남역, ...)
+    @Builder.Default
+    private String subwayStationName = "";
 
     @Override
     public String toString() {

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/subway_station/dto/response/SubwayStationResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/subway_station/dto/response/SubwayStationResponse.java
@@ -1,16 +1,13 @@
 package com.sullung2yo.seatcatcher.domain.subway_station.dto.response;
 
-import com.sullung2yo.seatcatcher.domain.subway_station.entity.SubwayStation;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import com.sullung2yo.seatcatcher.domain.subway_station.entity.SubwayStation;
 
 @Getter
-@Setter
-@NoArgsConstructor
+@Builder
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "요청에 응답하기 위한 역에 대한 DTO입니다.")
 public class SubwayStationResponse {
 
@@ -35,6 +32,7 @@ public class SubwayStationResponse {
     @Schema(description = "처음 역에서부터 해당 역까지 오는 데에 필요한 누계 거리입니다. km 단위입니다.")
     private Float acmlDist;
 
+    // ✅ 컨트롤러가 사용하는 엔티티 생성자 복구
     public SubwayStationResponse(SubwayStation subwayStation) {
         this.id = subwayStation.getId();
         this.name = subwayStation.getStationName();

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/tag/dto/TagDTO.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/tag/dto/TagDTO.java
@@ -2,17 +2,14 @@ package com.sullung2yo.seatcatcher.domain.tag.dto;
 
 import com.sullung2yo.seatcatcher.domain.tag.enums.UserTagType;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+
+import lombok.*;
 
 @Getter
-@Setter
+@Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TagDTO {
 
-    List<UserTagType> tags;
-
+    private List<UserTagType> tags;
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/tag/dto/response/TagResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/tag/dto/response/TagResponse.java
@@ -5,10 +5,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
-@Setter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "Tag 응답 DTO")
 public class TagResponse {
 

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/TrainCarDTO.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/TrainCarDTO.java
@@ -1,18 +1,13 @@
 package com.sullung2yo.seatcatcher.domain.train.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
-@Setter
+@Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TrainCarDTO {
 
     private String trainCode;
-
     private String carCode;
-
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/CascadeTrainSeatResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/CascadeTrainSeatResponse.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @Schema(description = "어떤 그룹에 속한 좌석들에 대한 기본 정보, 거기에 앉은 유저 정보, 유저의 현재 이용중인 경로까지 다 담고 있을 DTO입니다.")
 public class CascadeTrainSeatResponse extends TrainSeatResponse {

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/IncomingTrainsResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/IncomingTrainsResponse.java
@@ -3,41 +3,38 @@ package com.sullung2yo.seatcatcher.domain.train.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.Builder;
-import lombok.Data;
-import lombok.ToString;
+import lombok.*;
 
-@Data
-@Schema(
-        description = "열차 도착 정보 응답 DTO",
-        title = "열차 도착 정보 응답 DTO"
-)
-@Tag(name="TrainSeatGroup API", description = "열차 관련 API")
-@ToString
+@Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+@Schema(description = "열차 도착 정보 응답 DTO", title = "열차 도착 정보 응답 DTO")
+@Tag(name="TrainSeatGroup API", description = "열차 관련 API")
 public class IncomingTrainsResponse {
 
     @JsonProperty("btrainNo")
     @Schema(description = "지하철 ID", example = "1001")
-    private String subwayId; // btrainNo
+    private String subwayId;
 
     @JsonProperty("ordkey")
-    @Schema(description = "도착 예정 열차 순번", example = "11002온수0 -> 상하행코드1자리, 순번1자리, 현재역3자리, 목적지정류장, 급행코드1자리\n 12004석남0 -> 하행/두번째열차/004번역/석남행/급행아님")
-    private String arrivalTrainOrder; // ordkey
+    @Schema(description = "도착 예정 열차 순번", example = "11002온수0 ...")
+    private String arrivalTrainOrder;
 
     @JsonProperty("barvlDt")
     @Schema(description = "도착 예정 시간", example = "180(초)")
-    private String arrivalTime; // barvlDt
+    private String arrivalTime;
 
     @JsonProperty("arvlMsg2")
     @Schema(description = "첫 번째 도착 메시지", example = "도착, 출발, 진입 등")
-    private String arrivalMessage; // arvlMsg2
+    private String arrivalMessage;
 
     @JsonProperty("arvlCd")
-    @Schema(description = "도착 코드", example = "0:진입, 1:도착, 2:출발, 3:전역출발, 4:전역진입, 5:전역도착, 99:운행중")
-    private Integer arrivalCode; // arvlCd
+    @Schema(description = "도착 코드", example = "0:진입, 1:도착 ...")
+    private Integer arrivalCode;
 
     @JsonProperty("bstatnNm")
     @Schema(description = "종착역 이름", example = "서울역")
-    private String destinationStationName; // bstatnNm
+    private String destinationStationName;
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/SeatInfoResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/SeatInfoResponse.java
@@ -1,20 +1,18 @@
 package com.sullung2yo.seatcatcher.domain.train.dto.response;
 
 import com.sullung2yo.seatcatcher.domain.train.enums.SeatGroupType;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
-@Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString
 public class SeatInfoResponse {
-    private String trainCode; // 기차 코드
-    private String carCode; // 차량 코드
-    private SeatGroupType seatGroupType; // 좌석 그룹 타입
-    private List<SeatStatus> seatStatus; // 좌석 상태 리스트
+    private String trainCode;
+    private String carCode;
+    private SeatGroupType seatGroupType;
+    private List<SeatStatus> seatStatus;
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/SeatOccupant.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/SeatOccupant.java
@@ -2,21 +2,20 @@ package com.sullung2yo.seatcatcher.domain.train.dto.response;
 
 import com.sullung2yo.seatcatcher.domain.user.enums.ProfileImageNum;
 import com.sullung2yo.seatcatcher.domain.tag.enums.UserTagType;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SeatOccupant {
-    private Long userId; // 사용자 ID
-    private String nickname; // 사용자 닉네임
-    private LocalDateTime expectedArrivalTime; // 도착역까지 얼마나 남았는지
-    private ProfileImageNum profileImageNum; // 프로필 이미지 번호
-    private String getOffStationName; // 도착역 이름
-    private List<UserTagType> tags; // 사용자 태그 목록
+    private Long userId;
+    private String nickname;
+    private LocalDateTime expectedArrivalTime;
+    private ProfileImageNum profileImageNum;
+    private String getOffStationName;
+    private List<UserTagType> tags;
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/SeatStatus.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/SeatStatus.java
@@ -1,18 +1,16 @@
 package com.sullung2yo.seatcatcher.domain.train.dto.response;
 
 import com.sullung2yo.seatcatcher.domain.train.enums.SeatType;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 @Getter
-@Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString
 public class SeatStatus {
-    private Long seatId; // 좌석 ID
-    private Integer seatLocation; // 좌석 위치 (0 .. 14 또는 0 .. 12, ...)
-    private SeatType seatType; // 좌석 타입 (일반석, 노약자석, ...)
-    private SeatOccupant occupant; // 좌석 점유자 정보
+    private Long seatId;
+    private Integer seatLocation;
+    private SeatType seatType;
+    private SeatOccupant occupant;
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/SeatYieldAcceptRejectResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/SeatYieldAcceptRejectResponse.java
@@ -6,31 +6,32 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
-@Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "좌석 양보 수락/거절 응답 객체", title = "SeatYieldAcceptRejectResponse")
 public class SeatYieldAcceptRejectResponse {
 
     @Schema(description = "좌석 ID", example = "1")
-    Long seatId;
+    private Long seatId;
 
     @NotNull
     @Schema(description = "좌석 점유자 User Id", example = "1")
-    Long ownerId;
+    private Long ownerId;
 
     @NotNull
     @Schema(description = "양보 요청을 보낸 사람의 user id", example = "1")
-    Long oppositeUserId;
+    private Long oppositeUserId;
 
     @NotNull
     @Schema(description = "좌석 점유자 닉네임", example = "asdfasdf")
-    String ownerNickname;
+    private String ownerNickname;
 
     @NotNull
     @Schema(description = "좌석 점유자 프로필 이미지 번호", example = "IMAGE_1")
-    ProfileImageNum ownerProfileImageNum;
+    private ProfileImageNum ownerProfileImageNum;
 
     @NotNull
     @Schema(description = "좌석 양보 수락 여부", example = "true")
-    Boolean isAccepted;
+    private Boolean isAccepted;
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/SeatYieldCanceledResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/SeatYieldCanceledResponse.java
@@ -6,23 +6,24 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
-@Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "좌석 양보 요청 취소 응답 객체", title = "SeatYieldCanceledResponse")
 public class SeatYieldCanceledResponse {
 
     @Schema(description = "좌석 ID", example = "1")
-    Long seatId;
+    private Long seatId;
 
     @NotNull
     @Schema(description = "좌석 양보 요청을 취소한 사람의 User Id", example = "1")
-    Long requestUserId;
+    private Long requestUserId;
 
     @NotNull
     @Schema(description = "좌석 양보 요청을 취소한 사람의 닉네임", example = "asdfasdf")
-    String requestUserNickname;
+    private String requestUserNickname;
 
     @NotNull
     @Schema(description = "좌석 양보 요청을 취소한 사람의 프로필 이미지 번호", example = "IMAGE_1")
-    ProfileImageNum requestUserProfileImageNum;
+    private ProfileImageNum requestUserProfileImageNum;
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/SeatYieldRequestResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/SeatYieldRequestResponse.java
@@ -10,8 +10,9 @@ import java.util.List;
 
 
 @Getter
-@Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString
 @Schema(description = "좌석 양보 요청 응답 객체", title = "SeatYieldRequestResponse")
 public class SeatYieldRequestResponse {

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/TempSeatYieldRequestResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/TempSeatYieldRequestResponse.java
@@ -3,14 +3,12 @@ package com.sullung2yo.seatcatcher.domain.train.dto.response;
 import com.sullung2yo.seatcatcher.domain.user.enums.ProfileImageNum;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 @Getter
-@Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString
 @Schema(description = "좌석 양보 요청 응답 객체", title = "SeatYieldRequestResponse")
 public class TempSeatYieldRequestResponse {

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/TrainSeatResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/TrainSeatResponse.java
@@ -3,15 +3,11 @@ package com.sullung2yo.seatcatcher.domain.train.dto.response;
 import com.sullung2yo.seatcatcher.domain.train.enums.SeatType;
 import com.sullung2yo.seatcatcher.domain.train.entity.TrainSeat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "어떤 좌석 자체에 대한 정보를 담은 DTO입니다.")
 public class TrainSeatResponse {
     @Schema(description = "좌석의 ID입니다. Primary Key 로 사용됩니다.")

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/UserTrainSeatResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/train/dto/response/UserTrainSeatResponse.java
@@ -3,15 +3,12 @@ package com.sullung2yo.seatcatcher.domain.train.dto.response;
 import com.sullung2yo.seatcatcher.domain.train.entity.UserTrainSeat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
-@Setter
-@NoArgsConstructor
+@Builder
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "착석 정보에 대한 Response DTO입니다.")
 public class UserTrainSeatResponse {
     @Schema(description = "착석 정보의 ID입니다. Primary Key 로 사용됩니다.")

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/user/dto/request/UserInformationUpdateRequest.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/user/dto/request/UserInformationUpdateRequest.java
@@ -7,8 +7,10 @@ import lombok.*;
 
 import java.util.List;
 
-@Data
+@Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "사용자 정보 수정 요청 DTO")
 public class UserInformationUpdateRequest {
 

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/user/dto/response/UserInformationResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/user/dto/response/UserInformationResponse.java
@@ -3,15 +3,14 @@ package com.sullung2yo.seatcatcher.domain.user.dto.response;
 import com.sullung2yo.seatcatcher.domain.user.enums.ProfileImageNum;
 import com.sullung2yo.seatcatcher.domain.tag.enums.UserTagType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
-@Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "사용자 정보 응답 DTO")
 public class UserInformationResponse {
 

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/user_status/dto/request/UserStatusRequest.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/user_status/dto/request/UserStatusRequest.java
@@ -4,10 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "유저 상태값 Request DTO")
 public class UserStatusRequest {
 
@@ -22,5 +21,4 @@ public class UserStatusRequest {
 
     @Schema(description = "유저가 양보를 요청했던 좌석의 ID (구독 유지를 위함)", example = "123")
     private Long seatIdRequested;
-
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/user_status/dto/response/UserStatusResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/user_status/dto/response/UserStatusResponse.java
@@ -3,11 +3,13 @@ package com.sullung2yo.seatcatcher.domain.user_status.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "유저 상태값 Response DTO")
 public class UserStatusResponse {
 
@@ -22,5 +24,4 @@ public class UserStatusResponse {
 
     @Schema(description = "유저가 양보를 요청했던 좌석의 ID (구독 유지를 위함)")
     private Long seatIdRequested;
-
 }

--- a/src/main/java/com/sullung2yo/seatcatcher/domain/user_status/dto/response/UserStatusResponse.java
+++ b/src/main/java/com/sullung2yo/seatcatcher/domain/user_status/dto/response/UserStatusResponse.java
@@ -3,9 +3,6 @@ package com.sullung2yo.seatcatcher.domain.user_status.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
-
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/test/java/com/sullung2yo/seatcatcher/domain/auth/AppleAuthTest.java
+++ b/src/test/java/com/sullung2yo/seatcatcher/domain/auth/AppleAuthTest.java
@@ -31,90 +31,62 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class AppleAuthTest {
 
-    @Mock
-    private UserRepository userRepository; // user repository 의존 Mocking
+    @Mock private UserRepository userRepository;
+    @Mock private JwtTokenProviderImpl jwtTokenProvider;
+    @Mock private NameGenerator nameGenerator;
+    @Mock private WebClient.Builder webClientBuilder;
+    @Mock private WebClient webClient;
+    @Mock private ResourceLoader resourceLoader;
 
-    @Mock
-    private JwtTokenProviderImpl jwtTokenProvider; // jwtTokenProvider 의존 Mocking
-
-    @Mock
-    private NameGenerator nameGenerator; // 랜덤 이름 생성기 Mocking
-
-    @Mock
-    private WebClient.Builder webClientBuilder; // webClient 사용해서 apple 서버와 통신, 테스트 환경에서는 불가 -> Mocking
-
-    @Mock
-    private WebClient webClient; // webClient 사용해서 apple 서버와 통신, 테스트 환경에서는 불가 -> Mocking
-
-    @Mock
-    private ResourceLoader resourceLoader; // 리소스 로더 Mocking
-
-//    private AuthServiceImpl authService; // 테스트 대상 인스턴스
-
-    private AuthService authService; // 테스트 대상 인스턴스
+    private AuthService authService;
 
     @BeforeEach
     void setUp() {
-        when(webClientBuilder.build()).thenReturn(webClient); // webClientBuilder.build() 호출 시 Mocked webClient 반환하도록 설정
-        authService = new AuthServiceImpl(userRepository, jwtTokenProvider, webClientBuilder, nameGenerator, resourceLoader); // 테스트 대상 인스턴스 생성
-        ReflectionTestUtils.setField(authService, "appleClientId", "com.example.app"); // 테스트 appleClientId 설정
+        when(webClientBuilder.build()).thenReturn(webClient);
+        authService = new AuthServiceImpl(userRepository, jwtTokenProvider, webClientBuilder, nameGenerator, resourceLoader);
+        ReflectionTestUtils.setField(authService, "appleClientId", "com.example.app");
     }
 
-    /**
-     * 새로운 사용자가 Apple 로그인 시도하는 경우 테스트
-     *
-     * @throws Exception 예외 발생 시 Exception
-     */
     @Test
     void testAppleAuthentication_NewUser() throws Exception {
         // Given
-        AppleAuthRequest request = new AppleAuthRequest();
-        request.setIdentityToken("fake.apple.token");
-        request.setFcmToken("fcmToken");
-        request.setNonce("test-nonce");
-        request.setAuthorizationCode("fake-auth-code");
+        AppleAuthRequest request = AppleAuthRequest.builder()
+                .identityToken("fake.apple.token")
+                .fcmToken("fcmToken")
+                .nonce("test-nonce")
+                .authorizationCode("fake-auth-code")
+                .build();
         String appleUserId = "apple123";
 
-        // When
-        // Spying : 실제 객체를 감싸고, 특정 메서드만 가짜 동작을 하도록 설정하는 방법
-//        AuthServiceImpl authServiceSpy = spy(authService); // authService 인스턴스를 spy로 생성 (가짜 객체 생성)
-        AuthService authServiceSpy = spy(authService); // authService 인스턴스를 spy로 생성 (가짜 객체 생성)
-
-        // Spying한 validateAppleIdentityToken 메서드 호출 시 테스트로 설정한 appleUserId 반환하도록 Mocking
+        // Spy는 구현체로!
+        AuthServiceImpl authServiceSpy = spy((AuthServiceImpl) authService);
         doReturn(appleUserId).when(authServiceSpy).validateAppleIdentityToken(anyString(), anyString());
 
-        // 새로운 사용자라고 가정 (null을 반환했다고 가정)
         when(userRepository.findByProviderId(appleUserId)).thenReturn(Optional.empty());
+        when(jwtTokenProvider.createToken(eq(appleUserId), isNull(), eq(TokenType.ACCESS))).thenReturn("access_token");
+        when(jwtTokenProvider.createToken(eq(appleUserId), isNull(), eq(TokenType.REFRESH))).thenReturn("refresh_token");
 
-        // jwt 생성했다고 치고
-        when(jwtTokenProvider.createToken(eq(appleUserId), isNull(), eq(TokenType.ACCESS)))
-                .thenReturn("access_token");
-        when(jwtTokenProvider.createToken(eq(appleUserId), isNull(), eq(TokenType.REFRESH)))
-                .thenReturn("refresh_token");
-
-        // 토큰이 스파이 객체에서 잘 담기는지 테스트
+        // When
         List<String> tokens = authServiceSpy.authenticate(request, Provider.APPLE);
 
         // Then
         assertEquals(2, tokens.size());
         assertEquals("access_token", tokens.get(0));
         assertEquals("refresh_token", tokens.get(1));
-
-        // 사용자 저장되었는지 확인
         verify(userRepository).save(argThat(user ->
-                user.getProviderId().equals(appleUserId) &&
-                        user.getProvider() == Provider.APPLE
+                appleUserId.equals(user.getProviderId()) && user.getProvider() == Provider.APPLE
         ));
     }
 
     @Test
     void testAppleAuthentication_ExistingUser() throws Exception {
         // Given
-        AppleAuthRequest request = new AppleAuthRequest();
-        request.setIdentityToken("fake.apple.token");
-        request.setFcmToken("fcmToken");
-        request.setNonce("test-nonce");
-        request.setAuthorizationCode("fake-auth-code");
+        AppleAuthRequest request = AppleAuthRequest.builder()
+                .identityToken("fake.apple.token")
+                .fcmToken("fcmToken")
+                .nonce("test-nonce")
+                .authorizationCode("fake-auth-code")
+                .build();
         String appleUserId = "apple123";
         LocalDateTime now = LocalDateTime.now();
 
@@ -124,21 +96,12 @@ class AppleAuthTest {
                 .role(UserRole.ROLE_USER)
                 .build();
 
-        // authService Spying
-//        AuthServiceImpl authServiceSpy = spy(authService);
-        AuthService authServiceSpy = spy(authService);
-
-        // Spying한 validateAppleIdentityToken 메서드 호출 시 테스트로 설정한 appleUserId 반환하도록 Mocking
+        AuthServiceImpl authServiceSpy = spy((AuthServiceImpl) authService);
         doReturn(appleUserId).when(authServiceSpy).validateAppleIdentityToken(anyString(), anyString());
 
-        // 사용자 DB에서 찾았다고 가정
         when(userRepository.findByProviderId(appleUserId)).thenReturn(Optional.of(existingUser));
-
-        // jwt 생성했다고 치고
-        when(jwtTokenProvider.createToken(eq(appleUserId), isNull(), eq(TokenType.ACCESS)))
-                .thenReturn("access_token");
-        when(jwtTokenProvider.createToken(eq(appleUserId), isNull(), eq(TokenType.REFRESH)))
-                .thenReturn("refresh_token");
+        when(jwtTokenProvider.createToken(eq(appleUserId), isNull(), eq(TokenType.ACCESS))).thenReturn("access_token");
+        when(jwtTokenProvider.createToken(eq(appleUserId), isNull(), eq(TokenType.REFRESH))).thenReturn("refresh_token");
 
         // When
         List<String> tokens = authServiceSpy.authenticate(request, Provider.APPLE);
@@ -147,25 +110,24 @@ class AppleAuthTest {
         assertEquals(2, tokens.size());
         assertEquals("access_token", tokens.get(0));
         assertEquals("refresh_token", tokens.get(1));
-
-        // 사용자 정보 존재 및 로그인 정보 업데이트되었는지 확인
         verify(userRepository).save(argThat(user ->
-                user.getProviderId().equals(appleUserId) &&
-                        user.getProvider() == Provider.APPLE &&
-                        user.getLastLoginAt().isAfter(now)
+                appleUserId.equals(user.getProviderId())
+                        && user.getProvider() == Provider.APPLE
+                        && user.getLastLoginAt().isAfter(now)
         ));
     }
 
     @Test
     void testAppleAuthentication_InvalidToken() {
         // Given
-        AppleAuthRequest request = new AppleAuthRequest();
-        request.setIdentityToken("invalid.token");
-        request.setFcmToken("fcmToken");
+        AppleAuthRequest request = AppleAuthRequest.builder()
+                .identityToken("invalid.token")
+                .fcmToken("fcmToken")
+                .build();
 
         // When/Then
-        Exception exception = assertThrows(TokenException.class, () ->
-                authService.authenticate(request, Provider.APPLE));
+        Exception exception = assertThrows(TokenException.class,
+                () -> authService.authenticate(request, Provider.APPLE));
         assertTrue(exception.getMessage().contains("Identity Token 파싱 실패"));
     }
 }

--- a/src/test/java/com/sullung2yo/seatcatcher/domain/auth/KakaoAuthTest.java
+++ b/src/test/java/com/sullung2yo/seatcatcher/domain/auth/KakaoAuthTest.java
@@ -31,103 +31,51 @@ import static org.mockito.Mockito.*;
  * Kakao 로그인 인증 로직에 대한 단위 테스트 클래스.
  * WebClient를 통한 실제 카카오 서버와 통신하는게 아니라, Mock 객체를 사용해 테스트한다.
  */
-@ExtendWith(MockitoExtension.class) // Mockito를 편리하게 사용하도록 설정하는 Annotation -> @Mock, @InjectMocks 등을 메서드마다 선언하지 않게 해준다.
+@ExtendWith(MockitoExtension.class)
 class KakaoAuthTest {
 
-    // Mock 필드 - 가짜 객체를 사용하기 위해 선언하는 필드
+    @Mock private UserRepository userRepository;
+    @Mock private JwtTokenProviderImpl jwtTokenProvider;
+    @Mock private NameGenerator nameGenerator;
+    @Mock private WebClient.Builder webClientBuilder;
+    @Mock private WebClient webClient;
+    @Mock private ResourceLoader resourceLoader;
 
-    @Mock
-    private UserRepository userRepository;
-    // 이 테스트 케이스는 UserRepository를 테스트하는게 아니라, 카카오 인증 자체에 대한 테스트를 수행하므로 실제 UserRepository를 사용하지 않고 Mock 객체를 사용함
+    @Mock private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+    @Mock private WebClient.RequestHeadersSpec requestHeadersSpec;
+    @Mock private WebClient.ResponseSpec responseSpec;
+    @Mock private Mono<KakaoUserDataResponse> monoResponse;
 
-    @Mock
-    private JwtTokenProviderImpl jwtTokenProvider;
-    // JWT 발급도 실제 작동할 필요 X -> Mocking
+    private AuthService authService;
 
-    @Mock
-    private NameGenerator nameGenerator;
-
-    @Mock
-    private WebClient.Builder webClientBuilder;
-    // 실제 코드에서 WebClient Builder를 사용하는데, 테스트 환경에서는 사용 불가 -> Mocking
-
-    @Mock
-    private WebClient webClient;
-    // WebClient는 외부와 통신할 때 사용하는 객체이므로, 테스트 환경에서는 사용 불가 -> Mocking
-
-    @Mock
-    private ResourceLoader resourceLoader;
-    // ResourceLoader Mocking
-
-    // ====================Web Client 체이닝 메서드 호출에 필요한 다양한 타입 Mocking===========================
-    // WebClient -> RequestHeadersUriSpec -> RequestHeadersSpec -> ResponseSpec -> Mono<KakaoUserDataResponse> 순으로 호출되므로
-    // 각각의 Mock 객체를 생성하여 WebClient의 메서드 호출에 대한 반환값을 설정해준다.
-
-    @Mock
-    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
-
-    @Mock
-    private WebClient.RequestHeadersSpec requestHeadersSpec;
-
-    @Mock
-    private WebClient.ResponseSpec responseSpec;
-
-    @Mock
-    private Mono<KakaoUserDataResponse> monoResponse;
-
-    // =================================================================================================
-
-//    private AuthServiceImpl authService; // 실제 테스트 대상 객체
-
-    private AuthService authService; // 실제 테스트 대상 객체
-
-    /**
-     * 각 테스트 메서드 실행 전(BeforeEach)에 공통으로 수행할 셋업 로직.
-     * WebClient 체이닝을 Mock으로 연결해줌과 동시에, 테스트 대상 서비스 인스턴스를 생성한다.
-     */
     @BeforeEach
     void setUp() {
-        // 1. WebClient Builder Mocking
         when(webClientBuilder.build()).thenReturn(webClient);
-
-        // 2. GET 요청 시 requestHeadersUriSpec을 반환하는 Mocking 설정
         when(webClient.get()).thenReturn(requestHeadersUriSpec);
-
-        // 3. REQUEST URI 설정 시 requestHeadersSpec을 반환하는 Mocking 설정
         when(requestHeadersUriSpec.uri(anyString())).thenReturn(requestHeadersSpec);
-
-        // 4. Header 설정 시 requestHeadersSpec을 반환하는 Mocking 설정
         when(requestHeadersSpec.header(anyString(), anyString())).thenReturn(requestHeadersSpec);
-
-        // 5. Response 시 responseSpec을 반환하는 Mocking 설정
         when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
 
-        // authService 인스턴스 생성해야 하니까 Mocking WebClient + 필요한 의존성 주입
         authService = new AuthServiceImpl(userRepository, jwtTokenProvider, webClientBuilder, nameGenerator, resourceLoader);
     }
 
     @Test
     void testKakaoAuthentication_NewUser() throws Exception {
         // Given
-        KakaoAuthRequest request = new KakaoAuthRequest();
-        request.setAccessToken("fake-token");
+        KakaoAuthRequest request = KakaoAuthRequest.builder()
+                .accessToken("fake-token")
+                .build();
 
-        // Create mock Kakao response - 카카오 인증 서버에서 "kakao-123" 반환했다고 가정
-        KakaoUserDataResponse kakaoResponse = new KakaoUserDataResponse();
-        kakaoResponse.setId("kakao-123");
+        KakaoUserDataResponse kakaoResponse = KakaoUserDataResponse.builder()
+                .id("kakao-123")
+                .build();
 
-        // Mock WebClient response
         when(responseSpec.bodyToMono(KakaoUserDataResponse.class)).thenReturn(monoResponse);
         when(monoResponse.block()).thenReturn(kakaoResponse);
 
-        // 실제로 DB에는 없을거니까 kakao-123 쿼리했을 때 반환되는게 없을거라고 가정
         when(userRepository.findByProviderId("kakao-123")).thenReturn(Optional.empty());
-
-        // JWT 잘 생성했다고 가정
-        when(jwtTokenProvider.createToken(eq("kakao-123"), isNull(), eq(TokenType.ACCESS)))
-                .thenReturn("access-token");
-        when(jwtTokenProvider.createToken(eq("kakao-123"), isNull(), eq(TokenType.REFRESH)))
-                .thenReturn("refresh-token");
+        when(jwtTokenProvider.createToken(eq("kakao-123"), isNull(), eq(TokenType.ACCESS))).thenReturn("access-token");
+        when(jwtTokenProvider.createToken(eq("kakao-123"), isNull(), eq(TokenType.REFRESH))).thenReturn("refresh-token");
 
         // When
         List<String> tokens = authService.authenticate(request, Provider.KAKAO);
@@ -138,43 +86,36 @@ class KakaoAuthTest {
         assertEquals("access-token", tokens.get(0));
         assertEquals("refresh-token", tokens.get(1));
 
-        // 사용자 저장되었는지 테스트 (실제로 저장되는건 아님)
         verify(userRepository).save(argThat(user ->
-                user.getProviderId().equals("kakao-123") &&
-                        user.getProvider() == Provider.KAKAO &&
-                        user.getRole() == UserRole.ROLE_USER
+                user.getProviderId().equals("kakao-123")
+                        && user.getProvider() == Provider.KAKAO
+                        && user.getRole() == UserRole.ROLE_USER
         ));
     }
 
     @Test
     void testKakaoAuthentication_ExistingUser() throws Exception {
         // Given
-        KakaoAuthRequest request = new KakaoAuthRequest();
-        request.setAccessToken("fake-token");
+        KakaoAuthRequest request = KakaoAuthRequest.builder()
+                .accessToken("fake-token")
+                .build();
 
-        // Create mock Kakao response - 카카오 인증 서버에서 "kakao-123" 반환했다고 가정
-        KakaoUserDataResponse kakaoResponse = new KakaoUserDataResponse();
-        kakaoResponse.setId("kakao-123");
+        KakaoUserDataResponse kakaoResponse = KakaoUserDataResponse.builder()
+                .id("kakao-123")
+                .build();
 
-        // 현재 DB에 이 사용자 존재한다고 가정
         User existingUser = User.builder()
                 .providerId("kakao-123")
                 .provider(Provider.KAKAO)
                 .role(UserRole.ROLE_USER)
                 .build();
 
-        // Mock WebClient response
         when(responseSpec.bodyToMono(KakaoUserDataResponse.class)).thenReturn(monoResponse);
         when(monoResponse.block()).thenReturn(kakaoResponse);
 
-        // 실제 DB에 쿼리하는게 아니므로 existingUser 반환한다고 설정
         when(userRepository.findByProviderId("kakao-123")).thenReturn(Optional.of(existingUser));
-
-        // Mock JWT token generation
-        when(jwtTokenProvider.createToken(anyString(), isNull(), eq(TokenType.ACCESS)))
-                .thenReturn("access-token");
-        when(jwtTokenProvider.createToken(anyString(), isNull(), eq(TokenType.REFRESH)))
-                .thenReturn("refresh-token");
+        when(jwtTokenProvider.createToken(anyString(), isNull(), eq(TokenType.ACCESS))).thenReturn("access-token");
+        when(jwtTokenProvider.createToken(anyString(), isNull(), eq(TokenType.REFRESH))).thenReturn("refresh-token");
 
         // When
         List<String> tokens = authService.authenticate(request, Provider.KAKAO);
@@ -183,23 +124,21 @@ class KakaoAuthTest {
         assertNotNull(tokens);
         assertEquals(2, tokens.size());
 
-        // Verify user was updated
         verify(userRepository).save(argThat(user -> user.getProviderId().equals("kakao-123")));
     }
 
     @Test
     void testKakaoAuthentication_ApiFailure() {
         // Given
-        KakaoAuthRequest request = new KakaoAuthRequest();
-        request.setAccessToken("invalid-token");
+        KakaoAuthRequest request = KakaoAuthRequest.builder()
+                .accessToken("invalid-token")
+                .build();
 
         when(responseSpec.bodyToMono(KakaoUserDataResponse.class)).thenReturn(monoResponse);
         when(monoResponse.block()).thenReturn(null);
 
         // When/Then
-        Exception exception = assertThrows(Exception.class, () -> {
-            authService.authenticate(request, Provider.KAKAO);
-        });
+        Exception exception = assertThrows(Exception.class, () -> authService.authenticate(request, Provider.KAKAO));
         assertEquals("카카오 서버에서 사용자 정보를 가져오는데 실패했습니다.", exception.getMessage());
     }
 }

--- a/src/test/java/com/sullung2yo/seatcatcher/domain/auth/controller/TokenControllerTest.java
+++ b/src/test/java/com/sullung2yo/seatcatcher/domain/auth/controller/TokenControllerTest.java
@@ -5,7 +5,6 @@ import com.sullung2yo.seatcatcher.common.domain.TokenType;
 import com.sullung2yo.seatcatcher.common.jwt.provider.JwtTokenProviderImpl;
 import com.sullung2yo.seatcatcher.domain.auth.enums.Provider;
 import com.sullung2yo.seatcatcher.domain.user.entity.User;
-
 import com.sullung2yo.seatcatcher.domain.auth.dto.request.TokenRefreshRequest;
 import com.sullung2yo.seatcatcher.domain.auth.repository.RefreshTokenRepository;
 import com.sullung2yo.seatcatcher.domain.user.repository.UserRepository;
@@ -31,10 +30,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class TokenControllerTest {
 
     @Autowired
-    MockMvc mockMvc; // 요청 보내주는 MockMvc 객체
+    MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper; // JSON 변환을 위한 ObjectMapper 객체
+    ObjectMapper objectMapper;
 
     @Autowired
     private JwtTokenProviderImpl jwtTokenProvider;
@@ -62,18 +61,18 @@ class TokenControllerTest {
     @Test
     @DisplayName("토큰 갱신 테스트")
     void testRefreshToken() throws Exception {
-        //Given
+        // Given
         String refreshToken = jwtTokenProvider.createToken(testUser.getProviderId(), null, TokenType.REFRESH);
-        TokenRefreshRequest tokenRefreshRequest = new TokenRefreshRequest();
-        tokenRefreshRequest.setRefreshToken(refreshToken);
+        TokenRefreshRequest tokenRefreshRequest = TokenRefreshRequest.builder()
+                .refreshToken(refreshToken)
+                .build();
 
-        //When
         String requestBody = objectMapper.writeValueAsString(tokenRefreshRequest);
 
-        //Then
+        // When / Then
         mockMvc.perform(post("/token/refresh")
-                        .contentType(MediaType.APPLICATION_JSON) // ContentType 설정
-                        .content(requestBody) // RequestBody 설정
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
                 )
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -86,15 +85,15 @@ class TokenControllerTest {
     void testExpiredRefreshToken() throws Exception {
         // Given
         ReflectionTestUtils.setField(jwtTokenProvider, "refreshTokenValidMilliseconds", 0L);
-        String expired_refreshToken = jwtTokenProvider.createToken(testUser.getProviderId(), null, TokenType.REFRESH);
+        String expiredRefreshToken = jwtTokenProvider.createToken(testUser.getProviderId(), null, TokenType.REFRESH);
 
-        TokenRefreshRequest tokenRefreshRequest = new TokenRefreshRequest();
-        tokenRefreshRequest.setRefreshToken(expired_refreshToken);
+        TokenRefreshRequest tokenRefreshRequest = TokenRefreshRequest.builder()
+                .refreshToken(expiredRefreshToken)
+                .build();
 
-        // When
         String requestBody = objectMapper.writeValueAsString(tokenRefreshRequest);
 
-        // Then
+        // When / Then
         mockMvc.perform(post("/token/refresh")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody)
@@ -111,7 +110,7 @@ class TokenControllerTest {
         // Given
         String accessToken = jwtTokenProvider.createToken(testUser.getProviderId(), null, TokenType.ACCESS);
 
-        // When
+        // When / Then
         mockMvc.perform(get("/token/validate")
                         .header("Authorization", "Bearer " + accessToken)
                 )
@@ -127,7 +126,7 @@ class TokenControllerTest {
         ReflectionTestUtils.setField(jwtTokenProvider, "accessTokenValidMilliseconds", 0L);
         String expiredAccessToken = jwtTokenProvider.createToken(testUser.getProviderId(), null, TokenType.ACCESS);
 
-        // When
+        // When / Then
         mockMvc.perform(get("/token/validate")
                         .header("Authorization", "Bearer " + expiredAccessToken)
                 )

--- a/src/test/java/com/sullung2yo/seatcatcher/domain/credit/controller/CreditControllerTest.java
+++ b/src/test/java/com/sullung2yo/seatcatcher/domain/credit/controller/CreditControllerTest.java
@@ -24,25 +24,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 class CreditControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private JwtTokenProviderImpl jwtTokenProvider;
-
-    @Autowired
-    ObjectMapper objectMapper; // JSON 변환을 위한 ObjectMapper 객체
+    @Autowired private MockMvc mockMvc;
+    @Autowired private UserRepository userRepository;
+    @Autowired private JwtTokenProviderImpl jwtTokenProvider;
+    @Autowired ObjectMapper objectMapper;
 
     private User user;
-
     private String accessToken;
 
     @BeforeEach
     void setUp() {
-        // 1. 사용자 생성
         user = userRepository.save(
                 User.builder()
                         .provider(Provider.APPLE)
@@ -52,8 +43,6 @@ class CreditControllerTest {
                         .profileImageNum(ProfileImageNum.IMAGE_1)
                         .build()
         );
-
-        // 2. 인증 토큰
         accessToken = jwtTokenProvider.createToken(user.getProviderId(), null, TokenType.ACCESS);
     }
 
@@ -67,9 +56,10 @@ class CreditControllerTest {
         Long beforeCredit = user.getCredit();
         Long amountToAdd = 100L;
 
-        CreditModificationRequest request = new CreditModificationRequest();
-        request.setAmount(amountToAdd);
-        request.setTargetUserId(user.getId());
+        CreditModificationRequest request = CreditModificationRequest.builder()
+                .amount(amountToAdd)
+                .targetUserId(user.getId())
+                .build();
 
         mockMvc.perform(
                         patch("/credit")
@@ -89,9 +79,10 @@ class CreditControllerTest {
         Long beforeCredit = user.getCredit();
         Long amountToMinus = 100L;
 
-        CreditModificationRequest request = new CreditModificationRequest();
-        request.setAmount(amountToMinus);
-        request.setTargetUserId(user.getId());
+        CreditModificationRequest request = CreditModificationRequest.builder()
+                .amount(amountToMinus)
+                .targetUserId(user.getId())
+                .build();
 
         mockMvc.perform(
                         patch("/credit")
@@ -109,9 +100,10 @@ class CreditControllerTest {
     @Test
     void invalidCreditModificationRequest() throws Exception {
         // 잘못된 요청: amount가 음수인 경우
-        CreditModificationRequest request = new CreditModificationRequest();
-        request.setAmount(-50L); // 음수로 설정
-        request.setTargetUserId(user.getId());
+        CreditModificationRequest request = CreditModificationRequest.builder()
+                .amount(-50L)
+                .targetUserId(user.getId())
+                .build();
 
         mockMvc.perform(
                         patch("/credit")

--- a/src/test/java/com/sullung2yo/seatcatcher/domain/subway_station/service/SubwayStationServiceImplTest.java
+++ b/src/test/java/com/sullung2yo/seatcatcher/domain/subway_station/service/SubwayStationServiceImplTest.java
@@ -73,8 +73,9 @@ class SubwayStationServiceImplTest {
     @Test
     void testSaveSubwayData() {
         // Given
-        SubwayStationData subwayStationData = new SubwayStationData();
-        subwayStationData.setSubwayLine("2");
+        SubwayStationData subwayStationData = SubwayStationData.builder()
+                .subwayLine("2")
+                .build();
 
         // When
         subwayStationService.saveSubwayData(List.of(subwayStationData));


### PR DESCRIPTION
### 개요 (Summary)

- 주요 DTO들을 불변 객체(Immutable DTO) 로 변경했습니다.
- 공통 포맷을 도입하여 일관성·안정성·가독성을 높였습니다.
- 기존 동작/응답 스키마는 변경하지 않고, Setter만 제거하는 것을 목표로 했습니다.
- DTO 변경에 의한 테스트 코드의 전면 수정도 했습니다.

### 왜 바꾸었나? (Why)

1. 예측 가능성
    - Setter가 있는 DTO는 생성 이후 값이 변경될 수 있어 사이드이펙트가 발생합니다.
    - 불변화로 “생성 시 확정 → 이후 불변”을 보장합니다.

2. 스레드 안전성
    - 비동기/멀티스레드 환경(이벤트, 알림 전송 등)에서 상태 변조 리스크를 줄입니다.

3. 버그 방지/디버깅 용이
    - “누가 언제 값을 바꿨는가?”를 추적할 필요가 없어집니다.
    - DTO는 데이터 컨테이너에 집중하고, 로직은 서비스/매퍼로 분리됩니다.

4. 일관된 코드 스타일
    - 팀 내 모든 DTO가 같은 규칙으로 작성되어 리뷰와 유지보수가 쉬워집니다.

5. 범위 (Scope)
    - *Request, *Response, 일부 내부 전송용 DTO에 대해 Setter 제거 및 불변화.
    - 엔티티→DTO 변환 생성자 혹은 정적 팩토리 유지/보완(필요한 곳만).
    - 비즈니스 로직/엔드포인트 계약(필드/JSON 스키마) 변경 없음.

### 공통 포맷 (Conventions)

모든 DTO에 아래 패턴을 기본으로 적용했습니다.
- @Getter (읽기 전용 접근자)
- @Builder (가독성 높은 생성)
- @AllArgsConstructor (필드 전체 생성자)
- @NoArgsConstructor(access = AccessLevel.PROTECTED) (Jackson 역직렬화/JPA 호환)
- @Schema 등 Swagger 주석 유지
- ❌ @Setter 제거 (생성 이후 변경 금지)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 없음

- 문서화
  - 여러 DTO에 클래스/필드 수준의 OpenAPI/Swagger 주석 추가로 API 명세 가독성 향상.

- 리팩터링
  - 다수 요청/응답 DTO에서 공개 세터 제거, 빌더/전체-인자 생성자 도입 및 기본 생성자 접근을 protected로 축소해 불변성 강화.
  - 일부 응답 DTO 필드 가시성/포맷 정리(toString 포함) 및 매핑 생성자 추가.
  - 임포트 정리 등 경미한 코드 스타일 개선.

- 테스트
  - 테스트 코드 전반에서 빌더 사용으로 테스트 데이터 생성 간소화 및 모킹 정리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->